### PR TITLE
Improve naming convention for download! method arguments

### DIFF
--- a/lib/fun_sftp.rb
+++ b/lib/fun_sftp.rb
@@ -43,12 +43,12 @@ module FunSftp
       client.upload!(src, converted_target, opts)
     end
 
-    def download!(target, src) #fetch locally from remote
+    def download!(remote, local) #fetch from remote to local
       opts = { progress: DownloadCallbacks.new, recursive: true}
-      converted_target = clean_path(target)
+      converted_remote_path = clean_path(remote)
       opts.delete(:progress) unless FunSftp.loggable?
-      opts.delete(:recursive) unless has_directory?(target)
-      client.download!(converted_target, src, opts)
+      opts.delete(:recursive) unless has_directory?(remote)
+      client.download!(converted_remote_path, local, opts)
     end
 
     def read(path) #read a file


### PR DESCRIPTION
Before: The #download! method copies the "target" to the "source" (???)
Now: The #download! method copies the "remote" to the "local"

This avoids a great deal of confusion when inspecting the signature of the method, since the source in a download action is the remote file, not the local file.

This change does not change the API itself since the change is contained within the scope of the download! method only, and the arguments are still in the same order.