### PR TITLE
[DEFECT] NoMethodError: undefined method `Pathname'

### DIFF
--- a/lib/fun_sftp.rb
+++ b/lib/fun_sftp.rb
@@ -8,6 +8,7 @@ require 'fun_sftp/download_callbacks'
 orig_verbose = $VERBOSE
 $VERBOSE = nil
 require 'net/sftp'
+require 'pathname'
 $VERBOSE = orig_verbose
 
 # Reference: http://net-ssh.rubyforge.org/sftp/v2/api/


### PR DESCRIPTION
Problem: When calling the chdir method, a NoMethod error is thrown with message: "undefined method 'Pathname'"

Analysis: The actual exception is thrown from the private method clean_path, on the following code line:
    Pathname(join_to_pwd(path)).cleanpath.to_path

Fix: Added require for 'pathname'

Ruby version: 2.4.2